### PR TITLE
hook for how model is created

### DIFF
--- a/rest_witchcraft/routers.py
+++ b/rest_witchcraft/routers.py
@@ -7,7 +7,7 @@ from django_sorcery.db.meta import model_info
 
 
 class DefaultRouter(routers.DefaultRouter):
-    def get_default_basename(self, viewset):
+    def get_default_base_name(self, viewset):
 
         model = getattr(viewset, "get_model", lambda: None)()
 
@@ -18,6 +18,9 @@ class DefaultRouter(routers.DefaultRouter):
         )
 
         return model.__name__.lower()
+
+    # for backwards compatibility DRF<3.9
+    get_default_basename = get_default_base_name
 
     def get_lookup_regex(self, viewset, lookup_prefix=""):
         """

--- a/rest_witchcraft/serializers.py
+++ b/rest_witchcraft/serializers.py
@@ -691,11 +691,17 @@ class ModelSerializer(BaseSerializer):
             self._errors = e.detail
             raise e
 
+    def create_model(self):
+        """
+        Hook to allow to customize how model is created in create flow
+        """
+        return self.model()
+
     def create(self, validated_data):
         """
         Creates a model instance using validated_data
         """
-        instance = self.update(self.Meta.model(), validated_data)
+        instance = self.update(self.create_model(), validated_data)
         self.session.add(instance)
         return instance
 

--- a/rest_witchcraft/serializers.py
+++ b/rest_witchcraft/serializers.py
@@ -702,7 +702,7 @@ class ModelSerializer(BaseSerializer):
             self._errors = e.detail
             raise e
 
-    def create_model(self):
+    def create_model(self, validated_data):
         """
         Hook to allow to customize how model is created in create flow
         """
@@ -712,7 +712,7 @@ class ModelSerializer(BaseSerializer):
         """
         Creates a model instance using validated_data
         """
-        instance = self.update(self.create_model(), validated_data)
+        instance = self.update(self.create_model(validated_data), validated_data)
         self.session.add(instance)
         return instance
 

--- a/rest_witchcraft/serializers.py
+++ b/rest_witchcraft/serializers.py
@@ -620,15 +620,26 @@ class ModelSerializer(BaseSerializer):
         in validated data, we physically mark all other fields
         as not required to effectively make them partial without
         using ``partial`` flag itself.
+        To make serializer behave more or less like real partial serializer,
+        only passed keys in input data are preserved in validated data.
+        If they are not stripped, it is possible to remove some existing data.
         """
-        if self.partial_by_pk and self.get_primary_keys(data):
-            info = model_info(getattr(self.Meta, "model"))
+        if not self.partial_by_pk or not self.get_primary_keys(data):
+            return super(ModelSerializer, self).to_internal_value(data)
 
-            for name, field in self.fields.items():
-                if field.source not in info.primary_keys:
-                    field.required = False
+        info = model_info(getattr(self.Meta, "model"))
 
-        return super(ModelSerializer, self).to_internal_value(data)
+        for name, field in self.fields.items():
+            if field.source not in info.primary_keys:
+                field.required = False
+
+        passed_keys = set(data)
+        data = super(ModelSerializer, self).to_internal_value(data)
+
+        for k in set(data) - passed_keys:
+            data.pop(k)
+
+        return data
 
     def get_primary_keys(self, validated_data):
         """

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1384,14 +1384,21 @@ class TestModelSerializer(SimpleTestCase):
         self.assertFalse(serializer.fields["last_name"].required)
 
     def test_to_internal_value_partial_by_pk_remove_extra_fields(self):
-        class ParentSerializer(ModelSerializer):
+        class VehicleSerializer(ModelSerializer):
+            class Meta:
+                model = Vehicle
+                session = session
+                fields = "__all__"
+
+        class OwnerSerializer(ModelSerializer):
+            vehicle = VehicleSerializer(partial_by_pk=True)
+
             class Meta:
                 model = Option
                 session = session
                 fields = "__all__"
-                extra_kwargs = {"vehicle": {"partial_by_pk": True}}
 
-        serializer = ParentSerializer(data={"id": 111, "name": "foo", "vehicle": {"id": 1}})
+        serializer = OwnerSerializer(data={"id": 111, "name": "foo", "vehicle": {"id": 1}})
 
         self.assertTrue(serializer.is_valid(), serializer.errors)
         self.assertEqual(serializer.validated_data["vehicle"], {"id": 1})

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1383,6 +1383,19 @@ class TestModelSerializer(SimpleTestCase):
         self.assertFalse(serializer.fields["first_name"].required)
         self.assertFalse(serializer.fields["last_name"].required)
 
+    def test_to_internal_value_partial_by_pk_remove_extra_fields(self):
+        class ParentSerializer(ModelSerializer):
+            class Meta:
+                model = Option
+                session = session
+                fields = "__all__"
+                extra_kwargs = {"vehicle": {"partial_by_pk": True}}
+
+        serializer = ParentSerializer(data={"id": 111, "name": "foo", "vehicle": {"id": 1}})
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertEqual(serializer.validated_data["vehicle"], {"id": 1})
+
 
 class TestExpandableModelSerializer(SimpleTestCase):
     def setUp(self):


### PR DESCRIPTION
allows to customize how model is created. for example this allows for serializer to be created for one model however data actually backed by another model in viewset. it will just require to overwrite `create_model` and `to_representation`. granted very niche need but allows for cleaner API