### PR TITLE
Use deep copy so that all arguments are copied by value

### DIFF
--- a/rest_witchcraft/serializers.py
+++ b/rest_witchcraft/serializers.py
@@ -42,7 +42,7 @@ class BaseSerializer(serializers.Serializer):
 
     def build_standard_field_kwargs(self, field_name, field_class, column_info):
         """Analyze model column to generate field kwargs."""
-        field_kwargs = column_info.field_kwargs.copy()
+        field_kwargs = copy.deepcopy(column_info.field_kwargs)
         field_kwargs["label"] = capfirst(" ".join(field_name.split("_")).strip())
         field_kwargs["allow_null"] = not field_kwargs.get("required", True)
 


### PR DESCRIPTION
This can go wrong if you use a list to store validators.  With shallow copy the validators list is maintained even if a new request is being processed.  The result is that the validators list grows larger with every request.  This is especially bad with `UniqueValidator` because old sessions get stuck in the list and you will get SQLAlchemy transaction errors like `sqlalchemy.exc.StatementError: (sqlalchemy.exc.InvalidRequestError) Can't reconnect until invalid transaction is rolled back`